### PR TITLE
Indirect offset adds register value to base 0x10 op.

### DIFF
--- a/asm.rb
+++ b/asm.rb
@@ -146,7 +146,7 @@ class Assembler
         op.error("Malformed indirect offset value #{inner}") unless INT_RE === offset && REG_RE === reg
         value = offset.to_i
         op.extend value
-        return INDIRECT_OFFSET
+        return INDIRECT_OFFSET + VALUES[reg]
       end
     end
 


### PR DESCRIPTION
This fixes the only discrepency between the output of this
implementation and the expected output in test.s:

``` diff
--- output-broken   2012-04-14 22:36:59.000000000 +1000
+++ output-fixed    2012-04-14 22:37:17.000000000 +1000
@@ -5,7 +5,7 @@
 6: 7dc1 001a
 9: a861
 10: 7c01 2000
-11: 2101 2000
+11: 2161 2000
 12: 8463
 13: 806d
 14: 7dc1 000d
```
